### PR TITLE
fix(cmd): show error when loading config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,9 @@ func initConfig() {
 
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	} else {
+		fmt.Printf("Error reading config from '%s': %v", viper.ConfigFileUsed(), err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
If viper fails to read the config file, the error is ignored. This is a fix.